### PR TITLE
refactor: Update user registration and profile handling to use fullna…

### DIFF
--- a/docs/MVP_API_SPECIFICATION.md
+++ b/docs/MVP_API_SPECIFICATION.md
@@ -693,26 +693,17 @@ Get authenticated user profile and preferences.
   "email": "user@example.com",
   "name": "John Doe",
   "email_verified": true,
-  "preferred_lang": "am",
   "created_at": "2025-08-25T10:30:00Z",
-  "last_login": "2025-08-25T10:30:00Z",
+  "last_lo-gin": "2025-08-25T10:30:00Z",
   "preferences": {
-    "lang": "am",
     "topics": ["economy", "agriculture", "politics"],
     "subscribed_sources": ["addisstandard", "ethiopianherald"],
-    "data_saver": true,
+    "send_notifications": false,
     "notifications": {
       "daily_brief": { "am": true, "pm": false }
     }
   },
-  "subscription": {
-    "plan": "free",
-    "source_limit": 5,
-    "current_subscriptions": 2
-  },
   "stats": {
-    "stories_read": 147,
-    "briefs_accessed": 23,
     "chat_queries": 8,
     "last_sync": "2025-08-25T09:15:00Z"
   }

--- a/internal/domain/contract/iuser_usecase.go
+++ b/internal/domain/contract/iuser_usecase.go
@@ -9,7 +9,7 @@ import (
 
 // UserUseCase defines the interface for user-related operations.
 type IUserUseCase interface {
-	Register(ctx context.Context, username, email, password, firstName, lastName string) (*entity.User, error)
+	Register(ctx context.Context, username, email, password, fullname string) (*entity.User, error)
 	Login(ctx context.Context, email, password string) (*entity.User, string, string, error)
 	Authenticate(ctx context.Context, accessToken string) (*entity.User, error)
 	RefreshToken(ctx context.Context, refreshToken string) (string, string, error)
@@ -19,7 +19,7 @@ type IUserUseCase interface {
 	PromoteUser(ctx context.Context, userID string) (*entity.User, error)
 	DemoteUser(ctx context.Context, userID string) (*entity.User, error)
 	UpdateProfile(ctx context.Context, userID string, updates map[string]interface{}) (*entity.User, error)
-	LoginWithOAuth(ctx context.Context, firstName, lastName, email string) (string, string, error)
+	LoginWithOAuth(ctx context.Context, fullname, email string) (string, string, error)
 	GetUserByID(ctx context.Context, userID string) (*entity.User, error)
 	UpdatePreferences(ctx context.Context, userID string, req dto.UpdatePreferencesRequest) (*entity.Preferences, error)
 }

--- a/internal/domain/entity/user.go
+++ b/internal/domain/entity/user.go
@@ -12,11 +12,8 @@ type NotificationsPreferences struct {
 
 // Preferences holds user-specific settings, embedded in the User document.
 type Preferences struct {
-	Lang              string                   `bson:"lang" json:"lang"`
 	Topics            []string                 `bson:"topics" json:"topics"`
 	SubscribedSources []string                 `bson:"subscribed_sources" json:"subscribed_sources"`
-	BriefType         string                   `bson:"brief_type" json:"brief_type"`
-	DataSaver         bool                     `bson:"data_saver" json:"data_saver"`
 	Notifications     NotificationsPreferences `bson:"notifications" json:"notifications"`
 }
 
@@ -24,15 +21,13 @@ type Preferences struct {
 type User struct {
 	ID           string      `bson:"_id,omitempty" json:"id"`
 	Username     string      `bson:"username" json:"username"`
+	Fullname     string      `bson:"fullname" json:"fullname"`
 	Email        string      `bson:"email" json:"email"`
 	PasswordHash string      `bson:"password_hash" json:"-"`
 	Role         UserRole    `bson:"role" json:"role"`
 	IsVerified   bool        `bson:"is_verified" json:"is_verified"`
 	CreatedAt    time.Time   `bson:"created_at" json:"created_at"`
 	UpdatedAt    time.Time   `bson:"updated_at" json:"updated_at"`
-	FirstName    *string     `bson:"firstname,omitempty" json:"firstname,omitempty"`
-	LastName     *string     `bson:"lastname,omitempty" json:"lastname,omitempty"`
-	AvatarURL    *string     `bson:"avatar_url,omitempty" json:"avatar_url,omitempty"`
 	Preferences  Preferences `bson:"preferences" json:"preferences"`
 }
 

--- a/internal/handler/http/auth_handler.go
+++ b/internal/handler/http/auth_handler.go
@@ -5,14 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"strings"
-
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"net/http"
+	"os"
 )
 
 type AuthHandler struct {
@@ -60,7 +58,8 @@ func (h *AuthHandler) HandleGoogleCallback(ctx *gin.Context) {
 		ctx.String(http.StatusUnauthorized, "invalid CSRF state token\n")
 		return
 	}
-	ctx.SetCookie("oauthState", "", -1, "/", "localhost", false, true)
+	cookieSecure := os.Getenv("OAUTH2_SET_COOKIE_SECURE")
+	ctx.SetCookie("oauthState", "", -1, "/", "", cookieSecure == "true", true) // Secure cookie == 'bool' is used to set default value
 
 	code := ctx.Query("code")
 	if code == "" {
@@ -91,16 +90,9 @@ func (h *AuthHandler) HandleGoogleCallback(ctx *gin.Context) {
 		ctx.String(http.StatusInternalServerError, fmt.Sprintf("Failed to decode user info: %v\n", err))
 	}
 
-	nameParts := strings.Split(userInfo.Name, " ")
-	var fName, lName string
-	if len(nameParts) >= 1 {
-		fName = nameParts[0]
-	}
-	if len(nameParts) == 2 {
-		lName = nameParts[1]
-	}
+	fullname := userInfo.Name
 
-	accessToken, refershToken, err := h.UserUseCase.LoginWithOAuth(requestCtx, fName, lName, userInfo.Email)
+	accessToken, refreshToken, err := h.UserUseCase.LoginWithOAuth(requestCtx, fullname, userInfo.Email)
 
 	if err != nil {
 		ctx.String(http.StatusInternalServerError, fmt.Sprintf("failed to login with OAuth: %v\n", err))
@@ -110,6 +102,6 @@ func (h *AuthHandler) HandleGoogleCallback(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{
 		"message":       "login successful",
 		"access token":  accessToken,
-		"refresh token": refershToken,
+		"refresh token": refreshToken,
 	})
 }

--- a/internal/handler/http/auth_handler.go
+++ b/internal/handler/http/auth_handler.go
@@ -46,7 +46,7 @@ func (h *AuthHandler) HandleGoogleLogin(ctx *gin.Context) {
 	b := make([]byte, 16)
 	rand.Read(b)
 	oauthStateString := base64.URLEncoding.EncodeToString(b)
-	ctx.SetCookie("oauthState", oauthStateString, 300, "/", "localhost", false, true)
+	ctx.SetCookie("oauthState", oauthStateString, 300, "/", "", false, true)
 
 	url := h.googleOauthConfig().AuthCodeURL(oauthStateString)
 	ctx.Redirect(http.StatusTemporaryRedirect, url)

--- a/internal/handler/http/auth_handler.go
+++ b/internal/handler/http/auth_handler.go
@@ -60,7 +60,7 @@ func (h *AuthHandler) HandleGoogleCallback(ctx *gin.Context) {
 		ctx.String(http.StatusUnauthorized, "invalid CSRF state token\n")
 		return
 	}
-	ctx.SetCookie("oauthState", "", -1, "/", "localhost", false, true)
+	ctx.SetCookie("oauthState", "", -1, "/", "", true, true)
 
 	code := ctx.Query("code")
 	if code == "" {

--- a/internal/handler/http/dto/request.go
+++ b/internal/handler/http/dto/request.go
@@ -26,7 +26,6 @@ type RegisterRequest struct {
 type UpdateUserRequest struct {
 	Username  *string `json:"username,omitempty" binding:"omitempty,min=3,max=32"`
 	Fullname  *string `json:"fullname,omitempty" binding:"omitempty,max=50"`
-	AvatarURL *string `json:"avatar_url,omitempty" binding:"omitempty,url"`
 }
 
 // ForgotPasswordRequest is the DTO for requesting password reset.

--- a/internal/handler/http/dto/request.go
+++ b/internal/handler/http/dto/request.go
@@ -2,11 +2,10 @@ package dto
 
 // CreateUserRequest is the DTO for creating a new user.
 type CreateUserRequest struct {
-	Username  string `json:"username" binding:"required,min=3,max=32"`
-	Email     string `json:"email" binding:"required,email"`
-	Password  string `json:"password" binding:"required,min=8,max=32,containsuppercase,containslowercase,containsdigit,containssymbol"`
-	FirstName string `json:"firstname" binding:"required,min=3,max=50"`
-	LastName  string `json:"lastname" binding:"required,min=3,max=50"`
+	Username string `json:"username" binding:"required,min=3,max=32"`
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8,max=32,containsuppercase,containslowercase,containsdigit,containssymbol"`
+	Fullname string `json:"fullname" binding:"required,min=3,max=50"`
 }
 
 // LoginRequest is the DTO for user login.
@@ -20,13 +19,13 @@ type RegisterRequest struct {
 	Username string `json:"username" binding:"required,min=3,max=32"`
 	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required,min=8,max=32"`
+	Fullname string `json:"fullname" binding:"required,min=3,max=50"`
 }
 
 // UpdateUserRequest is the DTO for updating user profile.
 type UpdateUserRequest struct {
 	Username  *string `json:"username,omitempty" binding:"omitempty,min=3,max=32"`
-	FirstName *string `json:"firstname,omitempty" binding:"omitempty,max=50"`
-	LastName  *string `json:"lastname,omitempty" binding:"omitempty,max=50"`
+	Fullname  *string `json:"fullname,omitempty" binding:"omitempty,max=50"`
 	AvatarURL *string `json:"avatar_url,omitempty" binding:"omitempty,url"`
 }
 

--- a/internal/handler/http/dto/response.go
+++ b/internal/handler/http/dto/response.go
@@ -10,6 +10,7 @@ import (
 type UserResponse struct {
 	ID          string         `json:"id"`
 	Username    string         `json:"username"`
+	Fullname    string         `json:"fullname"`
 	Email       string         `json:"email"`
 	Role        string         `json:"role"`
 	FirstName   *string        `json:"first_name"`
@@ -33,16 +34,10 @@ func ToUserResponse(user entity.User) UserResponse {
 		Username:  user.Username,
 		Email:     user.Email,
 		Role:      string(user.Role),
-		FirstName: user.FirstName,
-		LastName:  user.LastName,
-		AvatarURL: user.AvatarURL,
 		CreatedAt: user.CreatedAt.Format(time.RFC3339),
 		Preferences: PreferencesDTO{
-			Lang:              user.Preferences.Lang,
 			Topics:            user.Preferences.Topics,
 			SubscribedSources: user.Preferences.SubscribedSources,
-			BriefType:         user.Preferences.BriefType,
-			DataSaver:         user.Preferences.DataSaver,
 			Notifications: NotificationsDTO{ // This assumes your entity.Preferences has this nested struct
 				DailyBrief:   user.Preferences.Notifications.DailyBrief,
 				BreakingNews: user.Preferences.Notifications.BreakingNews,

--- a/internal/handler/http/user_handler.go
+++ b/internal/handler/http/user_handler.go
@@ -43,7 +43,7 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
-	_, err := h.userUsecase.Register(c.Request.Context(), req.Username, req.Email, req.Password, req.FirstName, req.LastName)
+	_, err := h.userUsecase.Register(c.Request.Context(), req.Username, req.Email, req.Password, req.Fullname)
 	if err != nil {
 		ErrorHandler(c, http.StatusConflict, err.Error())
 		return
@@ -220,16 +220,9 @@ func updateUserRequestToMap(req dto.UpdateUserRequest) map[string]interface{} {
 	if req.Username != nil {
 		updates["username"] = *req.Username
 	}
-	if req.FirstName != nil {
-		updates["firstname"] = *req.FirstName
+	if req.Fullname != nil {
+		updates["fullname"] = *req.Fullname
 	}
-	if req.LastName != nil {
-		updates["lastname"] = *req.LastName
-	}
-	if req.AvatarURL != nil {
-		updates["avatarURL"] = *req.AvatarURL
-	}
-
 	return updates
 }
 

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -494,8 +494,8 @@ func (uc *UserUsecase) UpdateProfile(ctx context.Context, userID string, updates
 	// check if the fullname is set to empty string
 	if val, ok := updates["fullname"]; ok {
 		if fullname, isString := val.(string); isString {
-			if strings.TrimSpace(fullname) == "" {
 				uc.logger.Warnf("User %s is attempting to set fullname to empty string", userID)
+				return nil, errors.New("fullname cannot be empty")
 			}
 		}
 	}


### PR DESCRIPTION
This pull request introduces significant enhancements to the user, source, and topic domain models, as well as their contracts and DTOs, to support richer user preferences, subscriptions, and better API response structures. It also adds new handlers and interfaces for sources and topics, and streamlines user registration and OAuth login to use a single `fullname` field. Below are the most important changes grouped by theme:

**User Model, Preferences, and Use Case Updates**
- Refactored the `User` entity to use a single `Fullname` field instead of separate `FirstName` and `LastName`, and added a nested `Preferences` struct (including topics, subscribed sources, and notification settings). The corresponding DTOs and API responses were updated to match these changes. [[1]](diffhunk://#diff-e802727c242ed2063006b7cccedfb4fd35cb71d0e53118b185d33039259d930bR7-R31) [[2]](diffhunk://#diff-640146e958104d84cc7055b15e0a5ae3925c7ed40b9d5c849a8c549e1fb59decR7-R12) [[3]](diffhunk://#diff-640146e958104d84cc7055b15e0a5ae3925c7ed40b9d5c849a8c549e1fb59decL21-R24) [[4]](diffhunk://#diff-9a565c6e53720c29b2a4ea1aac5929dad0e8dd24b364785aea2d5c12997b3c90L8-R8) [[5]](diffhunk://#diff-9a565c6e53720c29b2a4ea1aac5929dad0e8dd24b364785aea2d5c12997b3c90R22-R28) [[6]](diffhunk://#diff-f163a730613b62a05eb1464ea376ae29e8fac501cf7cc63b490186ed5bc2dd95R13-R20) [[7]](diffhunk://#diff-f163a730613b62a05eb1464ea376ae29e8fac501cf7cc63b490186ed5bc2dd95L35-R45)
- Extended the `IUserRepository` interface to support user subscriptions (add, remove, get subscriptions).
- Added an `UpdatePreferences` method to the `IUserUseCase` interface and corresponding DTOs for updating user preferences. [[1]](diffhunk://#diff-640146e958104d84cc7055b15e0a5ae3925c7ed40b9d5c849a8c549e1fb59decL21-R24) [[2]](diffhunk://#diff-9a565c6e53720c29b2a4ea1aac5929dad0e8dd24b364785aea2d5c12997b3c90R58-R84)

**Domain Entities and Contracts for Sources and Topics**
- Introduced new `Source` and `Topic` entities, including support for bilingual fields in topics. [[1]](diffhunk://#diff-7b1413aff2f1d00c0b8174c9e9c4d31257d0dd31284f006e1bd5a3ff068cbe91R1-R17) [[2]](diffhunk://#diff-8e7b88ad3cffa4987604062b7736ff0afa73052bf7847ed08e1d86b18672f9cbR1-R20)
- Defined repository and use case interfaces for sources and topics (`ISourceRepository`, `ISourceUsecase`, `ITopicRepository`, `ITopicUsecase`). [[1]](diffhunk://#diff-c0ce42f4c1cdf7e7f69cd81d4652fc0f8d2bb35a0acb86b95e198de0ca0c2cf1R1-R19) [[2]](diffhunk://#diff-94752e09f3daf4e9a20d7b940c71a4477c24b3c90760adc804c74d255011a9b8R1-R12) [[3]](diffhunk://#diff-77686a400913dfa4f0938a632d08c104e7bcd2c13c8e78bea8eda2b911716834R1-R12) [[4]](diffhunk://#diff-7c7f076611b10ae55a83c7d55250fae5b94340af882ae1da1dd7029c0bc4ff9aR1-R12)

**API Handlers and DTO Enhancements**
- Added a new `SourceHandler` with a `GetSources` endpoint to serve source data via the API.
- Expanded DTOs for topics, sources, subscriptions, and preferences to provide richer, spec-compliant API responses.

**OAuth and Registration Flow Improvements**
- Updated OAuth login and registration flows to use the new `fullname` field throughout the system, simplifying user creation and login logic. [[1]](diffhunk://#diff-163cfd10e88aa7fd0f4d90b7431658132fa0725b9565c792996c7e605deb31cdL94-R95) [[2]](diffhunk://#diff-163cfd10e88aa7fd0f4d90b7431658132fa0725b9565c792996c7e605deb31cdL113-R105) [[3]](diffhunk://#diff-640146e958104d84cc7055b15e0a5ae3925c7ed40b9d5c849a8c549e1fb59decR7-R12) [[4]](diffhunk://#diff-9a565c6e53720c29b2a4ea1aac5929dad0e8dd24b364785aea2d5c12997b3c90L8-R8) [[5]](diffhunk://#diff-9a565c6e53720c29b2a4ea1aac5929dad0e8dd24b364785aea2d5c12997b3c90R22-R28)

**Security and Cookie Handling**
- Improved cookie handling in OAuth callback to set the `Secure` attribute based on environment variable, ensuring better security in production.

These changes lay the groundwork for more robust user personalization and pave the way for future enhancements around user subscriptions, preferences, and content discovery.