### PR TITLE
Update/mikiasgoitom/user managment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,3 +24,13 @@ EMAIL_PORT=587
 EMAIL_USERNAME=your_address@gmail.com
 EMAIL_APP_PASSWORD=your_16_char_app_password
 EMAIL_FROM=your_address@gmail.com
+
+#OAuth2
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+OAUTH2_SET_COOKIE_SECURE=false # if it is secure else false
+
+# seeder
+SEED_ON_START=true
+SEED_ADMIN_EMAIL=
+SEED_ADMIN_PASSWORD=

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"log"
-	"os"
-
 	handlerHttp "github.com/RealEskalate/G6-NewsBrief/internal/handler/http"
 	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/config"
 	database "github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/database"
@@ -18,6 +15,8 @@ import (
 	"github.com/RealEskalate/G6-NewsBrief/internal/usecase"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
+	"log"
+	"os"
 )
 
 func main() {
@@ -60,7 +59,8 @@ func main() {
 	userCollection := mongoClient.Client.Database(dbName).Collection("users")
 	userRepo := mongodb.NewMongoUserRepository(userCollection)
 	tokenRepo := mongodb.NewTokenRepository(mongoClient.Client.Database(dbName).Collection("tokens"))
-
+	topicRepo := mongodb.NewTopicRepository(mongoClient.Client.Database(dbName).Collection("topics"))
+	sourceRepo := mongodb.NewSourceRepository(mongoClient.Client.Database(dbName).Collection("sources"))
 	// Dependency Injection: Services
 	hasher := passwordservice.NewHasher()
 	jwtSecret := os.Getenv("JWT_SECRET")
@@ -80,14 +80,16 @@ func main() {
 	// Dependency Injection: Usecases
 	emailUsecase := usecase.NewEmailVerificationUseCase(tokenRepo, userRepo, mailService, randomGenerator, uuidGenerator, baseURL)
 	userUsecase := usecase.NewUserUsecase(userRepo, tokenRepo, emailUsecase, hasher, jwtService, mailService, appLogger, appConfig, appValidator, uuidGenerator, randomGenerator)
-
+	topicUsecase := usecase.NewTopicUsecase(topicRepo)
+	sourceUsecase := usecase.NewSourceUsecase(sourceRepo)
+	subscriptionUsecase := usecase.NewSubscriptionUsecase(userRepo, sourceRepo)
 	// Pass Prometheus metrics to handlers or usecases as needed (import from metrics package)
 
 	// Setup API routes
 	appRouter := handlerHttp.NewRouter(
 		userUsecase, emailUsecase,
 		userRepo, tokenRepo, hasher, jwtService, mailService,
-		appLogger, appConfig, appValidator, uuidGenerator, randomGenerator,
+		appLogger, appConfig, appValidator, uuidGenerator, randomGenerator, sourceUsecase, topicUsecase, subscriptionUsecase,
 	)
 	appRouter.SetupRoutes(router)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,6 +1,13 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	handlerHttp "github.com/RealEskalate/G6-NewsBrief/internal/handler/http"
 	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/config"
 	database "github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/database"
@@ -10,14 +17,45 @@ import (
 	passwordservice "github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/password_service"
 	randomgenerator "github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/random_generator"
 	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/repository/mongodb"
+	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/seeder"
 	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/uuidgen"
 	"github.com/RealEskalate/G6-NewsBrief/internal/infrastructure/validator"
 	"github.com/RealEskalate/G6-NewsBrief/internal/usecase"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
-	"log"
-	"os"
 )
+
+func adminSeeder(userUsecase contract.IUserUseCase, userRepo contract.IUserRepository) {
+	// Add a -seed flag to run seeder before starting the server
+	seed := flag.Bool("seed", true, "run database seeder and exit")
+	flag.Parse()
+
+	// Optionally allow seeding via env (useful on Render/CI)
+	seedOnStart := os.Getenv("SEED_ON_START") == "true"
+
+	if *seed || seedOnStart {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		adminEmail := os.Getenv("SEED_ADMIN_EMAIL")
+		if adminEmail == "" {
+			adminEmail = "admin@newsbrief.local"
+		}
+		adminPassword := os.Getenv("SEED_ADMIN_PASSWORD")
+		if adminPassword == "" {
+			adminPassword = "ChangeMe123!"
+		}
+
+		if err := seeder.SeedAdminUsingUC(ctx, userUsecase, userRepo, adminEmail, adminPassword); err != nil {
+			log.Fatalf("seeding failed: %v", err)
+		}
+		log.Println("seeding completed")
+		// Exit if seeding-only mode
+		if *seed {
+			return
+		}
+	}
+}
 
 func main() {
 	// Load environment variables from .env file
@@ -52,9 +90,6 @@ func main() {
 	// Register custom validators
 	validator.RegisterCustomValidators()
 
-	// Initialize Gin router
-	router := gin.Default()
-
 	// Dependency Injection: Repositories
 	userCollection := mongoClient.Client.Database(dbName).Collection("users")
 	userRepo := mongodb.NewMongoUserRepository(userCollection)
@@ -85,12 +120,20 @@ func main() {
 	subscriptionUsecase := usecase.NewSubscriptionUsecase(userRepo, sourceRepo)
 	// Pass Prometheus metrics to handlers or usecases as needed (import from metrics package)
 
+	//---------------------- Admin seeder-------------------------------------
+	adminSeeder(userUsecase, userRepo)
+	//---------------------- end of admin seeder-------------------------------------
+
 	// Setup API routes
 	appRouter := handlerHttp.NewRouter(
 		userUsecase, emailUsecase,
 		userRepo, tokenRepo, hasher, jwtService, mailService,
 		appLogger, appConfig, appValidator, uuidGenerator, randomGenerator, sourceUsecase, topicUsecase, subscriptionUsecase,
 	)
+
+	// Initialize Gin router
+	router := gin.Default()
+
 	appRouter.SetupRoutes(router)
 
 	// Start the server
@@ -102,4 +145,5 @@ func main() {
 	if err := router.Run(":" + port); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	// Dependency Injection: Repositories
 	userCollection := mongoClient.Client.Database(dbName).Collection("users")
-	userRepo := mongodb.NewMongoUserRepository(userCollection)
+	userRepo := mongodb.NewUserRepository(userCollection)
 	tokenRepo := mongodb.NewTokenRepository(mongoClient.Client.Database(dbName).Collection("tokens"))
 	topicRepo := mongodb.NewTopicRepository(mongoClient.Client.Database(dbName).Collection("topics"))
 	sourceRepo := mongodb.NewSourceRepository(mongoClient.Client.Database(dbName).Collection("sources"))
@@ -114,7 +114,7 @@ func main() {
 	baseURL := appConfig.GetAppBaseURL()
 	// Dependency Injection: Usecases
 	emailUsecase := usecase.NewEmailVerificationUseCase(tokenRepo, userRepo, mailService, randomGenerator, uuidGenerator, baseURL)
-	userUsecase := usecase.NewUserUsecase(userRepo, tokenRepo, emailUsecase, hasher, jwtService, mailService, appLogger, appConfig, appValidator, uuidGenerator, randomGenerator)
+	userUsecase := usecase.NewUserUsecase(userRepo, tokenRepo, topicRepo, emailUsecase, hasher, jwtService, mailService, appLogger, appConfig, appValidator, uuidGenerator, randomGenerator)
 	topicUsecase := usecase.NewTopicUsecase(topicRepo)
 	sourceUsecase := usecase.NewSourceUsecase(sourceRepo)
 	subscriptionUsecase := usecase.NewSubscriptionUsecase(userRepo, sourceRepo)

--- a/docs/User_management.md
+++ b/docs/User_management.md
@@ -1,0 +1,209 @@
+## User & Auth API
+
+This document describes the API that is currently implemented. All endpoints return JSON. Base path: `/api/v1`.
+
+### Auth model
+
+- Authentication: Bearer JWT in `Authorization: Bearer <access_token>` for protected endpoints.
+- Token refresh: Uses long-lived refresh tokens. See Refresh Token.
+- Errors: `{ "error": string }` with appropriate HTTP status code.
+- Rate limiting: Global limiter is enabled; repeated requests may return 429.
+
+---
+
+## Authentication endpoints
+
+### Register
+
+- POST `/api/v1/auth/register`
+- Body:
+  - `username` string (3–32)
+  - `email` valid email
+  - `password` string (8–32, must include upper, lower, digit, symbol)
+  - `fullname` string (3–50)
+- Responses:
+  - 201: `{ "message": "User created successfully. Please check your email to verify your account." }`
+  - 409: `{ "error": "..." }` if conflict (e.g., email/username taken)
+
+### Login
+
+- POST `/api/v1/auth/login`
+- Body:
+  - `email` string, `password` string
+- Responses:
+  - 200: `{ "user": User, "access_token": string, "refresh_token": string }`
+  - 401: `{ "error": "Invalid credentials or unverified email" }`
+
+### Verify email
+
+- GET `/api/v1/auth/verify-email?verifier=<id>&token=<token>`
+- Responses:
+  - 200: `{ "message": "Email verified successfully", "user": User }`
+  - 400: `{ "error": "invalid token or expired token" }`
+
+### Request verification email
+
+- POST `/api/v1/auth/request-verification-email`
+- Body: `{ "user_id": string }`
+- Responses:
+  - 200: `{ "message": "Verification email sent successfully" }`
+  - 400/404/500: `{ "error": "..." }`
+
+### Forgot password
+
+- POST `/api/v1/auth/forgot-password`
+- Body: `{ "email": string }`
+- Response: 200 with message (even if email does not exist)
+
+### Reset password
+
+- POST `/api/v1/auth/reset-password`
+- Body: `{ "token": string, "verifier": string, "password": string(min 8) }`
+- Responses:
+  - 200: `{ "message": "Password reset successfully" }`
+  - 400: `{ "error": "Invalid or expired reset token" }`
+
+### Refresh token
+
+- POST `/api/v1/auth/refresh-token`
+- Body: `{ "refresh_token": string }`
+- Responses:
+  - 200: `{ "access_token": string, "refresh_token": string }`
+  - 401: `{ "error": "Invalid or expired refresh token" }`
+
+### Logout
+
+- POST `/api/v1/logout`
+- Body: `{ "refresh_token": string }`
+- Responses:
+  - 200: `{ "message": "Logged out successfully" }`
+  - 400/500: `{ "error": "..." }`
+
+### Google OAuth
+
+- GET `/api/v1/auth/google/login` → Redirects to Google OAuth consent.
+- GET `/api/v1/auth/google/callback?code=...&state=...`
+  - Success 200: `{ "message": "login successful", "access token": string, "refresh token": string }`
+
+---
+
+## User endpoints
+
+### Get public profile
+
+- GET `/api/v1/users/profile/:id`
+- Response:
+  - 200: `User`
+  - 404: `{ "error": "User not found" }`
+
+### Get current user (me)
+
+- GET `/api/v1/me` (auth required)
+- Header: `Authorization: Bearer <access_token>`
+- Response: 200: `User`
+
+### Update profile
+
+- PUT `/api/v1/me` (auth required)
+- Body (any subset):
+  - `username` string (3–32)
+  - `fullname` string (<=50)
+- Response: 200: `User`
+
+---
+
+## Subscriptions (me)
+
+### List subscriptions
+
+- GET `/api/v1/me/subscriptions` (auth required)
+- Response: 200: `{ "subscriptions": SubscriptionDetail[], "total_subscriptions": number, "subscription_limit": number }`
+
+### Add subscription
+
+- POST `/api/v1/me/subscriptions` (auth required)
+- Body: `{ "source_key": string }` (source slug)
+- Responses:
+  - 201: (no body)
+  - 403: `{ "error": "subscription limit reached" }`
+  - 400/500: `{ "error": "..." }`
+
+### Remove subscription
+
+- DELETE `/api/v1/me/subscriptions/:source_slug` (auth required)
+- Response: 200: `{ "message": "Successfully unsubscribed" }`
+
+---
+
+## Admin endpoints (overview)
+
+These routes are protected; only admins should be allowed. Current implementation checks `userID == "admin"` in code (subject to change).
+
+### Create topic
+
+- POST `/api/v1/topics` (auth required)
+- Body:
+  - `slug` string
+  - `label` { `en`: string, `am`: string }
+- Responses: 201 on success; errors return `{ "error": "..." }`
+
+### Create source
+
+- POST `/api/v1/sources` (auth required)
+- Body:
+  - `slug` string
+  - `name` string
+  - `description` string
+  - `url` string
+  - `logo_url` string
+  - `languages` string (e.g., "EN", "AM")
+  - `topics` string[]
+  - `reliability_score` number
+- Responses: 201 on success; errors return `{ "error": "..." }`
+
+---
+
+## Schemas
+
+### User
+
+```
+{
+	"id": string,
+	"username": string,
+	"fullname": string,
+	"email": string,
+	"role": string,
+	"first_name": string|null,
+	"last_name": string|null,
+	"avatar_url": string|null,
+	"created_at": RFC3339 string,
+	"preferences": {
+		"lang": string,
+		"topics": string[],
+		"subscribed_sources": string[],
+		"brief_type": string,
+		"data_saver": boolean,
+		"notifications": { "daily_brief": boolean, "breaking_news": boolean }
+	}
+}
+```
+
+### SubscriptionDetail
+
+```
+{
+	"source_slug": string,
+	"source_name": string,
+	"subscribed_at": string (optional),
+	"topics": string[]
+}
+```
+
+---
+
+## Notes
+
+- CORS is enabled for all origins and common methods/headers.
+- All times are returned as RFC3339 strings.
+- Error messages are intentionally generic for security on auth flows.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
+	github.com/mssola/user_agent v0.6.0
 	go.mongodb.org/mongo-driver v1.17.4
 	golang.org/x/crypto v0.41.0
 	golang.org/x/net v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/mssola/user_agent v0.6.0 h1:uwPR4rtWlCHRFyyP9u2KOV0u8iQXmS7Z7feTrstQwk4=
+github.com/mssola/user_agent v0.6.0/go.mod h1:TTPno8LPY3wAIEKRpAtkdMT0f8SE24pLRGPahjCH4uw=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/internal/domain/contract/ijwt_manager.go
+++ b/internal/domain/contract/ijwt_manager.go
@@ -15,5 +15,6 @@ type CustomClaims struct {
 }
 
 type RefreshClaims struct {
+	Role string `json:"role"`
 	jwt.RegisteredClaims
 }

--- a/internal/domain/contract/isource_repository.go
+++ b/internal/domain/contract/isource_repository.go
@@ -2,17 +2,17 @@ package contract
 
 import (
 	"context"
-
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
 )
 
 // ISourceRepository defines the persistence contract for Source entities.
 type ISourceRepository interface {
-	// Exists checks if a source with the given key exists.
-	Exists(ctx context.Context, key string) (bool, error)
-
-	// GetByKey retrieves a single source by its unique key.
-	GetByKey(ctx context.Context, key string) (*entity.Source, error)
+	CreateSource(ctx context.Context, source *entity.Source) error
+	// CheckSlugExists checks if a source with the given slug exists.
+	CheckSlugExists(ctx context.Context, slug string) (bool, error)
+	// GetBySlug retrieves a single source by its unique slug.
+	GetBySlug(ctx context.Context, slug string) (*entity.Source, error)
+	CheckURLExists(ctx context.Context, url string) (bool, error)
 
 	// GetAll retrieves all sources from the collection.
 	GetAll(ctx context.Context) ([]entity.Source, error)

--- a/internal/domain/contract/isource_usecase.go
+++ b/internal/domain/contract/isource_usecase.go
@@ -8,5 +8,6 @@ import (
 
 // ISourceUsecase defines the business logic contract for sources.
 type ISourceUsecase interface {
+	CreateSource(ctx context.Context, source *entity.Source) error
 	GetAll(ctx context.Context) ([]entity.Source, error)
 }

--- a/internal/domain/contract/itoken_repository.go
+++ b/internal/domain/contract/itoken_repository.go
@@ -11,6 +11,7 @@ type ITokenRepository interface {
 	CreateToken(ctx context.Context, token *entity.Token) error
 	GetTokenByID(ctx context.Context, id string) (*entity.Token, error)
 	GetTokenByUserID(ctx context.Context, userID string) (*entity.Token, error)
+	GetTokenByUserIDWithOpts(ctx context.Context, userID string, tokenType string) (*entity.Token, error)
 	UpdateToken(ctx context.Context, tokenID string, tokenHash string, expiry time.Time) error
 	GetTokenByVerifier(ctx context.Context, verifier string) (*entity.Token, error)
 	RevokeToken(ctx context.Context, id string) error

--- a/internal/domain/contract/itopic_repository.go
+++ b/internal/domain/contract/itopic_repository.go
@@ -8,5 +8,8 @@ import (
 
 // ITopicRepository defines the persistence contract for Topic entities.
 type ITopicRepository interface {
+	CreateTopic(ctx context.Context, topic *entity.Topic) error
+	// CheckSlugExists checks if a topic with the given slug exists.
+	CheckSlugExists(ctx context.Context, slug string) (bool, error)
 	GetAll(ctx context.Context) ([]entity.Topic, error)
 }

--- a/internal/domain/contract/itopic_repository.go
+++ b/internal/domain/contract/itopic_repository.go
@@ -10,6 +10,8 @@ import (
 type ITopicRepository interface {
 	CreateTopic(ctx context.Context, topic *entity.Topic) error
 	// CheckSlugExists checks if a topic with the given slug exists.
+	GetTopicByID(ctx context.Context, topicID string) (*entity.Topic, error)
 	CheckSlugExists(ctx context.Context, slug string) (bool, error)
 	GetAll(ctx context.Context) ([]entity.Topic, error)
+	GetUserSubscribedTopics(ctx context.Context, userTopics []string) ([]*entity.Topic, error)
 }

--- a/internal/domain/contract/itopic_usecase.go
+++ b/internal/domain/contract/itopic_usecase.go
@@ -2,11 +2,11 @@ package contract
 
 import (
 	"context"
-
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
 )
 
 // ITopicUsecase defines the business logic contract for topics.
 type ITopicUsecase interface {
+	CreateTopic(ctx context.Context, topic *entity.Topic) error
 	ListAll(ctx context.Context) ([]entity.Topic, error)
 }

--- a/internal/domain/contract/iuser_repository.go
+++ b/internal/domain/contract/iuser_repository.go
@@ -25,4 +25,6 @@ type IUserRepository interface {
 	RemoveSubscription(ctx context.Context, userID string, sourceKey string) error
 	// GetSubscriptions retrieves the list of subscribed source keys for a user.
 	GetSubscriptions(ctx context.Context, userID string) ([]string, error)
+	SubscribeTopic(ctx context.Context, userID, topicID string) error
+	GetUserSubscribedTopicsByID(ctx context.Context, userID string) ([]string, error)
 }

--- a/internal/domain/contract/iuser_usecase.go
+++ b/internal/domain/contract/iuser_usecase.go
@@ -22,4 +22,6 @@ type IUserUseCase interface {
 	LoginWithOAuth(ctx context.Context, fullname, email string) (string, string, error)
 	GetUserByID(ctx context.Context, userID string) (*entity.User, error)
 	UpdatePreferences(ctx context.Context, userID string, req dto.UpdatePreferencesRequest) (*entity.Preferences, error)
+	SubscribeTopic(ctx context.Context, userID, topicID string) error
+	GetUserSubscribedTopics(ctx context.Context, userID string) ([]*entity.Topic, error)
 }

--- a/internal/domain/entity/source.go
+++ b/internal/domain/entity/source.go
@@ -1,17 +1,34 @@
 package entity
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
-
 // Source represents a news outlet in the database.
 // It maps directly to a document in the 'sources' collection.
+
+type LanguageType string
+
+const (
+	LanguageEN LanguageType = "en"
+	LanguageAM LanguageType = "am"
+)
+
 type Source struct {
-	ID               primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	Key              string             `bson:"key" json:"key"`
-	Name             string             `bson:"name" json:"name"`
-	Description      string             `bson:"description" json:"description"`
-	URL              string             `bson:"url" json:"url"`
-	LogoURL          string             `bson:"logo_url" json:"logo_url"`
-	Languages        []string           `bson:"languages" json:"languages"`
-	Topics           []string           `bson:"topics" json:"topics"`
-	ReliabilityScore float64            `bson:"reliability_score" json:"reliability_score"`
+	ID               string       `bson:"_id,omitempty" json:"id"`
+	Slug             string       `bson:"slug" json:"slug"`
+	Name             string       `bson:"name" json:"name"`
+	Description      string       `bson:"description" json:"description"`
+	URL              string       `bson:"url" json:"url"`
+	LogoURL          string       `bson:"logo_url" json:"logo_url"`
+	Languages        LanguageType `bson:"languages" json:"languages"`
+	Topics           []string     `bson:"topics" json:"topics"`
+	ReliabilityScore float64      `bson:"reliability_score" json:"reliability_score"`
+}
+
+func SetLanguageType(lang string) LanguageType {
+	switch lang {
+	case "en":
+		return LanguageEN
+	case "am":
+		return LanguageAM
+	default:
+		return LanguageEN
+	}
 }

--- a/internal/domain/entity/token.go
+++ b/internal/domain/entity/token.go
@@ -2,9 +2,8 @@ package entity
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/golang-jwt/jwt/v5"
+	"time"
 )
 
 // Token represents an authentication token (access or refresh)

--- a/internal/domain/entity/topic.go
+++ b/internal/domain/entity/topic.go
@@ -1,7 +1,5 @@
 package entity
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
-
 // BilingualField represents a field with both English and Amharic translations.
 type BilingualField struct {
 	EN string `bson:"en" json:"en"`
@@ -10,11 +8,8 @@ type BilingualField struct {
 
 // Topic represents a news category.
 type Topic struct {
-	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	Key         string             `bson:"key" json:"key"`
-	Label       BilingualField     `bson:"label" json:"label"`
-	Description BilingualField     `bson:"description" json:"description"`
-	ImageURL    string             `bson:"image_url" json:"image_url"`
-	StoryCount  int                `bson:"story_count" json:"story_count"`
-	SortOrder   int                `bson:"sort_order" json:"-"`
+	ID         string         `bson:"_id,omitempty" json:"id"`
+	Slug       string         `bson:"slug" json:"slug"`
+	Label      BilingualField `bson:"label" json:"label"`
+	StoryCount int            `bson:"story_count" json:"story_count"`
 }

--- a/internal/handler/http/dto/request.go
+++ b/internal/handler/http/dto/request.go
@@ -24,9 +24,8 @@ type RegisterRequest struct {
 
 // UpdateUserRequest is the DTO for updating user profile.
 type UpdateUserRequest struct {
-	Username  *string `json:"username,omitempty" binding:"omitempty,min=3,max=32"`
-	Fullname  *string `json:"fullname,omitempty" binding:"omitempty,max=50"`
-	AvatarURL *string `json:"avatar_url,omitempty" binding:"omitempty,url"`
+	Username *string `json:"username,omitempty" binding:"omitempty,min=3,max=32"`
+	Fullname *string `json:"fullname,omitempty" binding:"omitempty,max=50"`
 }
 
 // ForgotPasswordRequest is the DTO for requesting password reset.

--- a/internal/handler/http/dto/response.go
+++ b/internal/handler/http/dto/response.go
@@ -1,9 +1,8 @@
 package dto
 
 import (
-	"time"
-
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
+	"time"
 )
 
 // UserResponse is the DTO for a user.

--- a/internal/handler/http/dto/response.go
+++ b/internal/handler/http/dto/response.go
@@ -62,24 +62,9 @@ type BilingualFieldDTO struct {
 	AM string `json:"am"`
 }
 
-// TopicDTO represents a single topic in the API response.
-type TopicDTO struct {
-	Key         string            `json:"key"`
-	Label       BilingualFieldDTO `json:"label"`
-	Description BilingualFieldDTO `json:"description"`
-	ImageURL    string            `json:"image_url"`
-	StoryCount  int               `json:"story_count"`
-}
-
-// TopicsResponseDTO is the response for the GET /v1/topics endpoint.
-type TopicsResponseDTO struct {
-	Topics      []TopicDTO `json:"topics"`
-	TotalTopics int        `json:"total_topics"`
-}
-
 // SubscriptionDetailDTO now matches the API spec.
 type SubscriptionDetailDTO struct {
-	SourceKey    string    `json:"source_key"`
+	SourceSlug   string    `json:"source_slug"`
 	SourceName   string    `json:"source_name"`
 	SubscribedAt time.Time `json:"subscribed_at"`
 	Topics       []string  `json:"topics"` // Per-subscription topics can be a future enhancement
@@ -104,12 +89,12 @@ type PreferencesDTO struct {
 
 // SourceDTO represents a single source in an API response.
 type SourceDTO struct {
-	Key              string   `json:"key"`
+	Slug             string   `json:"slug"`
 	Name             string   `json:"name"`
 	Description      string   `json:"description"`
 	URL              string   `json:"url"`
 	LogoURL          string   `json:"logo_url"`
-	Languages        []string `json:"languages"`
+	Languages        string   `json:"languages"`
 	Topics           []string `json:"topics"`
 	ReliabilityScore float64  `json:"reliability_score"`
 }
@@ -120,8 +105,56 @@ type SourcesResponseDTO struct {
 	TotalSources int         `json:"total_sources"`
 }
 
+// MapSourcesToDTOs converts a slice of source entities to a slice of DTOs.
+func MapSourcesToDTOs(sources []entity.Source) []SourceDTO {
+	sourceDTOs := make([]SourceDTO, len(sources))
+	for i, source := range sources {
+		sourceDTOs[i] = SourceDTO{
+			Slug:             source.Slug,
+			Name:             source.Name,
+			Description:      source.Description,
+			URL:              source.URL,
+			LogoURL:          source.LogoURL,
+			Languages:        string(source.Languages),
+			Topics:           source.Topics,
+			ReliabilityScore: source.ReliabilityScore,
+		}
+	}
+	return sourceDTOs
+}
+
 // NotificationsDTO defines the nested notifications object in API responses.
 type NotificationsDTO struct {
 	DailyBrief   bool `json:"daily_brief"`
 	BreakingNews bool `json:"breaking_news"`
+}
+
+// topics
+// TopicDTO represents a single topic in the API response.
+type TopicDTO struct {
+	Slug       string            `json:"slug"`
+	TopicName  string            `json:"topic_name"`
+	Label      BilingualFieldDTO `json:"label"`
+	StoryCount int               `json:"story_count"`
+}
+
+// TopicsResponseDTO is the response for the GET /v1/topics endpoint.
+type TopicsResponseDTO struct {
+	Topics      []TopicDTO `json:"topics"`
+	TotalTopics int        `json:"total_topics"`
+}
+
+func MapTopicsToDTOs(topics []entity.Topic) []TopicDTO {
+	topicDTOs := make([]TopicDTO, len(topics))
+	for i, topic := range topics {
+		topicDTOs[i] = TopicDTO{
+			Slug: topic.Slug,
+			Label: BilingualFieldDTO{
+				EN: topic.Label.EN,
+				AM: topic.Label.AM,
+			},
+			StoryCount: topic.StoryCount,
+		}
+	}
+	return topicDTOs
 }

--- a/internal/handler/http/dto/response.go
+++ b/internal/handler/http/dto/response.go
@@ -13,8 +13,6 @@ type UserResponse struct {
 	Fullname    string         `json:"fullname"`
 	Email       string         `json:"email"`
 	Role        string         `json:"role"`
-	FirstName   *string        `json:"first_name"`
-	LastName    *string        `json:"last_name"`
 	AvatarURL   *string        `json:"avatar_url"`
 	CreatedAt   string         `json:"created_at"`
 	Preferences PreferencesDTO `json:"preferences"`
@@ -32,6 +30,7 @@ func ToUserResponse(user entity.User) UserResponse {
 	return UserResponse{
 		ID:        user.ID,
 		Username:  user.Username,
+		Fullname:  user.Fullname,
 		Email:     user.Email,
 		Role:      string(user.Role),
 		CreatedAt: user.CreatedAt.Format(time.RFC3339),

--- a/internal/handler/http/middleware/auth.go
+++ b/internal/handler/http/middleware/auth.go
@@ -29,7 +29,8 @@ func AuthMiddleWare(jwtService contract.IJWTService, userUseCase contract.IUserU
 		}
 
 		ctx.Set("userID", claims.UserID)
-		ctx.Set("userRole", claims.Role)
+		// fixed failed type assertion, thus passed in the string version of claims.Role. it wasnt working on source_handler.go in the create source
+		ctx.Set("userRole", string(claims.Role))
 
 		ctx.Next()
 	}

--- a/internal/handler/http/middleware/device_detector.go
+++ b/internal/handler/http/middleware/device_detector.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mssola/user_agent"
+)
+
+type DeviceInfo struct {
+	Platform       string
+	Model          string
+	Browser        string
+	BrowserVersion string
+	IsMobile       bool
+	Source         string
+	RawUA          string
+	RawCH          string
+}
+
+func DeviceDetector() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		h := ctx.Request.Header
+		ch := map[string]string{
+			"Sec-CH-UA":                 h.Get("Sec-CH-UA"),
+			"Sec-CH-UA-Mobile":          h.Get("Sec-CH-UA-Mobile"),
+			"Sec-CH-UA-Platform":        h.Get("Sec-CH-UA-Platform"),
+			"Sec-CH-UA-Model":           h.Get("Sec-CH-UA-Model"),
+			"Sec-CH-UA-Browser":         h.Get("Sec-CH-UA-Browser"),
+			"Sec-CH-UA-Browser-Version": h.Get("Sec-CH-UA-Browser-Version"),
+		}
+
+		if ch["Sec-CH-UA"] != "" || ch["Sec-CH-UA-Mobile"] != "" {
+			info := &DeviceInfo{
+				Platform:       strings.Trim(ch["Sec-CH-UA-Platform"], `"`),
+				Model:          strings.Trim(ch["Sec-CH-UA-Model"], `"`),
+				Browser:        strings.Trim(ch["Sec-CH-UA-Browser"], `"`),
+				BrowserVersion: strings.Trim(ch["Sec-CH-UA-Browser-Version"], `"`),
+				IsMobile:       ch["Sec-CH-UA-Mobile"] == "true",
+				Source:         "client-hint",
+				RawUA:          "",
+				RawCH: strings.Join([]string{
+					ch["Sec-CH-UA"],
+					ch["Sec-CH-UA-Mobile"],
+					ch["Sec-CH-UA-Platform"],
+					ch["Sec-CH-UA-Model"],
+					ch["Sec-CH-UA-Browser"],
+					ch["Sec-CH-UA-Browser-Version"],
+				}, "; "),
+			}
+			ctx.Set("deviceInfo", &info)
+			ctx.Next()
+		}
+
+		uaStr := h.Get("User-Agent")
+		ua := user_agent.New(uaStr)
+		name, version := ua.Browser()
+		platform := ""
+		switch {
+		case ua.Platform() != "":
+			platform = ua.Platform()
+		case ua.OS() != "":
+			platform = ua.OS()
+		}
+		info := DeviceInfo{
+			Platform:       platform,
+			Model:          "",
+			Browser:        name,
+			BrowserVersion: version,
+			IsMobile:       ua.Mobile(),
+			Source:         "user-agent",
+			RawUA:          uaStr,
+			RawCH:          "",
+		}
+		ctx.Set("deviceInfo", &info)
+		ctx.Next()
+	}
+}
+
+// helper func
+func GetDeviceInfo(c *gin.Context) *DeviceInfo {
+	if v, ok := c.Get("deviceInfo"); ok {
+		if di, ok := v.(*DeviceInfo); ok {
+			return di
+		}
+	}
+	return nil
+}

--- a/internal/handler/http/router.go
+++ b/internal/handler/http/router.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/RealEskalate/G6-NewsBrief/internal/handler/http/middleware"
-	"github.com/RealEskalate/G6-NewsBrief/internal/usecase"
 	"github.com/didip/tollbooth/v7"
 	"github.com/didip/tollbooth/v7/limiter"
 	"github.com/gin-contrib/cors"
@@ -13,29 +12,34 @@ import (
 )
 
 type Router struct {
-	userHandler  *UserHandler
-	emailHandler *EmailHandler
-	userUsecase  *usecase.UserUsecase
-	jwtService   contract.IJWTService
-	authHandler  *AuthHandler
+	userHandler         *UserHandler
+	emailHandler        *EmailHandler
+	authHandler         *AuthHandler
+	sourceHandler       *SourceHandler
+	topicHandler        *TopicHandler
+	subscriptionHandler *SubscriptionHandler
+	userUsecase         contract.IUserUseCase
+	jwtService          contract.IJWTService
 }
 
-func NewRouter(userUsecase contract.IUserUseCase, emailVerUC contract.IEmailVerificationUC, userRepo contract.IUserRepository, tokenRepo contract.ITokenRepository, hasher contract.IHasher, jwtService contract.IJWTService, mailService contract.IEmailService, logger contract.IAppLogger, config contract.IConfigProvider, validator contract.IValidator, uuidGen contract.IUUIDGenerator, randomGen contract.IRandomGenerator) *Router {
+func NewRouter(userUsecase contract.IUserUseCase, emailVerUC contract.IEmailVerificationUC, userRepo contract.IUserRepository, tokenRepo contract.ITokenRepository, hasher contract.IHasher, jwtService contract.IJWTService, mailService contract.IEmailService, logger contract.IAppLogger, config contract.IConfigProvider, validator contract.IValidator, uuidGen contract.IUUIDGenerator, randomGen contract.IRandomGenerator, sourceUC contract.ISourceUsecase, topicUC contract.ITopicUsecase, subscriptionUC contract.ISubscriptionUsecase) *Router {
 	baseURL := config.GetAppBaseURL()
 	return &Router{
-		userHandler: NewUserHandler(userUsecase),
-
-		emailHandler: NewEmailHandler(emailVerUC, userRepo),
-		userUsecase:  usecase.NewUserUsecase(userRepo, tokenRepo, emailVerUC, hasher, jwtService, mailService, logger, config, validator, uuidGen, randomGen),
-		jwtService:   jwtService,
-		authHandler:  NewAuthHandler(userUsecase, baseURL),
+		userHandler:         NewUserHandler(userUsecase),
+		emailHandler:        NewEmailHandler(emailVerUC, userRepo),
+		authHandler:         NewAuthHandler(userUsecase, baseURL),
+		sourceHandler:       NewSourceHandler(sourceUC, uuidGen),
+		topicHandler:        NewTopicHandler(topicUC, uuidGen),
+		subscriptionHandler: NewSubscriptionHandler(subscriptionUC),
+		jwtService:          jwtService,
+		userUsecase:         userUsecase,
 	}
 }
 
 func (r *Router) SetupRoutes(router *gin.Engine) {
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"*"},
-		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Accept"},
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,
@@ -61,7 +65,6 @@ func (r *Router) SetupRoutes(router *gin.Engine) {
 		auth.POST("/forgot-password", r.userHandler.ForgotPassword)
 		auth.POST("/reset-password", r.userHandler.ResetPassword)
 		auth.POST("/refresh-token", r.userHandler.RefreshToken)
-
 		auth.POST("/request-verification-email", r.emailHandler.HandleRequestEmailVerification)
 
 		// Google OAuth endpoints
@@ -79,10 +82,19 @@ func (r *Router) SetupRoutes(router *gin.Engine) {
 	protected := v1.Group("/")
 	protected.Use(middleware.AuthMiddleWare(r.jwtService, r.userUsecase))
 	{
-		// Current user routes
+		// user routes
 		protected.GET("/me", r.userHandler.GetCurrentUser)
 		protected.PUT("/me", r.userHandler.UpdateUser)
-
+		protected.GET("/me/subscriptions", r.subscriptionHandler.GetSubscriptions)
+		protected.POST("/me/subscriptions", r.subscriptionHandler.AddSubscription)
+		protected.DELETE("/me/subscriptions/:source_slug", r.subscriptionHandler.RemoveSubscription)
+		// admin routes
+		protected.POST("/topics", r.topicHandler.CreateTopic)
+		// protected.POST("/topics/:id", r.topicHandler.UpdateTopic)
+		// protected.DELETE("/topics/:id", r.topicHandler.DeleteTopic)
+		protected.POST("/sources", r.sourceHandler.CreateSource)
+		// protected.PUT("/sources/:id", r.sourceHandler.UpdateSource)
+		// protected.DELETE("/sources/:id", r.sourceHandler.DeleteSource)
 	}
 
 	// Logout route (no authentication required just accept the refresh token from the request body and invalidate the user session)

--- a/internal/handler/http/router.go
+++ b/internal/handler/http/router.go
@@ -29,7 +29,7 @@ func NewRouter(userUsecase contract.IUserUseCase, emailVerUC contract.IEmailVeri
 		emailHandler:        NewEmailHandler(emailVerUC, userRepo),
 		authHandler:         NewAuthHandler(userUsecase, baseURL),
 		sourceHandler:       NewSourceHandler(sourceUC, uuidGen),
-		topicHandler:        NewTopicHandler(topicUC, uuidGen),
+		topicHandler:        NewTopicHandler(topicUC, userUsecase, uuidGen),
 		subscriptionHandler: NewSubscriptionHandler(subscriptionUC),
 		jwtService:          jwtService,
 		userUsecase:         userUsecase,
@@ -53,6 +53,7 @@ func (r *Router) SetupRoutes(router *gin.Engine) {
 
 	// router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	// router.GET("/api/v1/metrics", gin.WrapH(promhttp.Handler()))
+
 	// API v1 routes
 	v1 := router.Group("/api/v1")
 
@@ -61,42 +62,48 @@ func (r *Router) SetupRoutes(router *gin.Engine) {
 	{
 		auth.POST("/register", r.userHandler.CreateUser)
 		auth.POST("/login", r.userHandler.Login)
+		auth.POST("/refresh-token", r.userHandler.RefreshToken)
 		auth.GET("/verify-email", r.emailHandler.HandleVerifyEmailToken)
 		auth.POST("/forgot-password", r.userHandler.ForgotPassword)
 		auth.POST("/reset-password", r.userHandler.ResetPassword)
-		auth.POST("/refresh-token", r.userHandler.RefreshToken)
 		auth.POST("/request-verification-email", r.emailHandler.HandleRequestEmailVerification)
-
 		// Google OAuth endpoints
 		auth.GET("/google/login", r.authHandler.HandleGoogleLogin)
 		auth.GET("/google/callback", r.authHandler.HandleGoogleCallback)
 	}
 
-	// Public user routes
-	users := v1.Group("/users")
+	// Admin routes
+	admin := v1.Group("/admin")
+	admin.Use(middleware.AuthMiddleWare(r.jwtService, r.userUsecase))
 	{
-		users.GET("/profile/:id", r.userHandler.GetUser)
+		// admin routes
+		admin.POST("/create-topics", r.topicHandler.CreateTopic)
+		// admin.POST("/topics/:id", r.topicHandler.UpdateTopic)
+		// admin.DELETE("/topics/:id", r.topicHandler.DeleteTopic)
+		admin.POST("/create-sources", r.sourceHandler.CreateSource)
+		// admin.PUT("/sources/:id", r.sourceHandler.UpdateSource)
+		// admin.DELETE("/sources/:id", r.sourceHandler.DeleteSource)
 	}
 
-	// Protected routes (authentication required)
-	protected := v1.Group("/")
-	protected.Use(middleware.AuthMiddleWare(r.jwtService, r.userUsecase))
+	// user profile routes (authentication required)
+	userProfile := v1.Group("/me")
+	userProfile.Use(middleware.AuthMiddleWare(r.jwtService, r.userUsecase))
 	{
 		// user routes
-		protected.GET("/me", r.userHandler.GetCurrentUser)
-		protected.PUT("/me", r.userHandler.UpdateUser)
-		protected.GET("/me/subscriptions", r.subscriptionHandler.GetSubscriptions)
-		protected.POST("/me/subscriptions", r.subscriptionHandler.AddSubscription)
-		protected.DELETE("/me/subscriptions/:source_slug", r.subscriptionHandler.RemoveSubscription)
-		// admin routes
-		protected.POST("/topics", r.topicHandler.CreateTopic)
-		// protected.POST("/topics/:id", r.topicHandler.UpdateTopic)
-		// protected.DELETE("/topics/:id", r.topicHandler.DeleteTopic)
-		protected.POST("/sources", r.sourceHandler.CreateSource)
-		// protected.PUT("/sources/:id", r.sourceHandler.UpdateSource)
-		// protected.DELETE("/sources/:id", r.sourceHandler.DeleteSource)
+		userProfile.GET("", r.userHandler.GetCurrentUser)
+		userProfile.PUT("", r.userHandler.UpdateUser)
+		userProfile.GET("/subscriptions", r.subscriptionHandler.GetSubscriptions)
+		userProfile.POST("/subscriptions", r.subscriptionHandler.AddSubscription)
+		userProfile.DELETE("/subscriptions/:source_slug", r.subscriptionHandler.RemoveSubscription)
+		userProfile.GET("/topics", r.topicHandler.SubscribeTopic)
+		userProfile.GET("/subscribed-topics", r.topicHandler.GetUserSubscribedTopics)
 	}
-
+	// public api
+	public := v1.Group("")
+	{
+		public.GET("/topics", r.topicHandler.GetTopics)
+		public.GET("/sources", r.sourceHandler.GetSources)
+	}
 	// Logout route (no authentication required just accept the refresh token from the request body and invalidate the user session)
 	v1.POST("/logout", r.userHandler.Logout)
 }

--- a/internal/handler/http/router.go
+++ b/internal/handler/http/router.go
@@ -95,7 +95,7 @@ func (r *Router) SetupRoutes(router *gin.Engine) {
 		userProfile.GET("/subscriptions", r.subscriptionHandler.GetSubscriptions)
 		userProfile.POST("/subscriptions", r.subscriptionHandler.AddSubscription)
 		userProfile.DELETE("/subscriptions/:source_slug", r.subscriptionHandler.RemoveSubscription)
-		userProfile.GET("/topics", r.topicHandler.SubscribeTopic)
+		userProfile.POST("/topics", r.topicHandler.SubscribeTopic)
 		userProfile.GET("/subscribed-topics", r.topicHandler.GetUserSubscribedTopics)
 	}
 	// public api

--- a/internal/handler/http/source_handler.go
+++ b/internal/handler/http/source_handler.go
@@ -11,12 +11,48 @@ import (
 
 type SourceHandler struct {
 	sourceUsecase contract.ISourceUsecase
+	uuidGen       contract.IUUIDGenerator
 }
 
-func NewSourceHandler(sourceUC contract.ISourceUsecase) *SourceHandler {
+func NewSourceHandler(sourceUC contract.ISourceUsecase, uuidGen contract.IUUIDGenerator) *SourceHandler {
 	return &SourceHandler{
 		sourceUsecase: sourceUC,
+		uuidGen:       uuidGen,
 	}
+}
+
+// CreateSource handles the POST /v1
+func (h *SourceHandler) CreateSource(c *gin.Context) {
+	userID, exists := c.Get("userID")
+	if !exists || userID != "admin" {
+		c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "Forbidden: Admins only"})
+		return
+	}
+
+	var sourceDTO dto.SourceDTO
+	if err := c.ShouldBindJSON(&sourceDTO); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid request payload"})
+		return
+	}
+
+	source := entity.Source{
+		ID:               h.uuidGen.NewUUID(),
+		Slug:             sourceDTO.Slug,
+		Name:             sourceDTO.Name,
+		Description:      sourceDTO.Description,
+		URL:              sourceDTO.URL,
+		LogoURL:          sourceDTO.LogoURL,
+		Languages:        entity.SetLanguageType(sourceDTO.Languages),
+		Topics:           sourceDTO.Topics,
+		ReliabilityScore: sourceDTO.ReliabilityScore,
+	}
+
+	if err := h.sourceUsecase.CreateSource(c.Request.Context(), &source); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Failed to create source"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, dto.MessageResponse{Message: "Source created successfully"})
 }
 
 // GetSources handles the GET /v1/sources request.
@@ -28,27 +64,9 @@ func (h *SourceHandler) GetSources(c *gin.Context) {
 	}
 
 	response := dto.SourcesResponseDTO{
-		Sources:      mapSourcesToDTOs(sources),
+		Sources:      dto.MapSourcesToDTOs(sources),
 		TotalSources: len(sources),
 	}
 
 	c.JSON(http.StatusOK, response)
-}
-
-// mapSourcesToDTOs converts a slice of source entities to a slice of DTOs.
-func mapSourcesToDTOs(sources []entity.Source) []dto.SourceDTO {
-	sourceDTOs := make([]dto.SourceDTO, len(sources))
-	for i, source := range sources {
-		sourceDTOs[i] = dto.SourceDTO{
-			Key:              source.Key,
-			Name:             source.Name,
-			Description:      source.Description,
-			URL:              source.URL,
-			LogoURL:          source.LogoURL,
-			Languages:        source.Languages,
-			Topics:           source.Topics,
-			ReliabilityScore: source.ReliabilityScore,
-		}
-	}
-	return sourceDTOs
 }

--- a/internal/handler/http/source_handler.go
+++ b/internal/handler/http/source_handler.go
@@ -26,16 +26,12 @@ func NewSourceHandler(sourceUC contract.ISourceUsecase, uuidGen contract.IUUIDGe
 // CreateSource handles the POST /v1
 func (h *SourceHandler) CreateSource(c *gin.Context) {
 	userRole, exists := c.Get("userRole")
-	fmt.Printf("User role from context: %v, exists: %v\n", userRole, exists) // Debugging line
 	if !exists {
 		c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "Forbidden: Admins only"})
 		return
 	}
 	userRoleStr, ok := userRole.(string)
-	fmt.Printf("userRole type: %T, value: %#v\n", userRole, userRole)
-	fmt.Printf("userRoleStr type: %T, value: %#v\n", userRoleStr, userRoleStr)
 	if !ok || strings.TrimSpace(userRoleStr) != "admin" {
-		fmt.Printf("%v, %v, %v, %v \n", exists, ok, strings.TrimSpace(userRoleStr) != "admin", userRole) // Debugging line
 		c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "Forbidden: Admins only"})
 		return
 	}

--- a/internal/handler/http/source_handler.go
+++ b/internal/handler/http/source_handler.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
@@ -23,8 +25,17 @@ func NewSourceHandler(sourceUC contract.ISourceUsecase, uuidGen contract.IUUIDGe
 
 // CreateSource handles the POST /v1
 func (h *SourceHandler) CreateSource(c *gin.Context) {
-	userID, exists := c.Get("userID")
-	if !exists || userID != "admin" {
+	userRole, exists := c.Get("userRole")
+	fmt.Printf("User role from context: %v, exists: %v\n", userRole, exists) // Debugging line
+	if !exists {
+		c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "Forbidden: Admins only"})
+		return
+	}
+	userRoleStr, ok := userRole.(string)
+	fmt.Printf("userRole type: %T, value: %#v\n", userRole, userRole)
+	fmt.Printf("userRoleStr type: %T, value: %#v\n", userRoleStr, userRoleStr)
+	if !ok || strings.TrimSpace(userRoleStr) != "admin" {
+		fmt.Printf("%v, %v, %v, %v \n", exists, ok, strings.TrimSpace(userRoleStr) != "admin", userRole) // Debugging line
 		c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "Forbidden: Admins only"})
 		return
 	}

--- a/internal/handler/http/subscription_handler.go
+++ b/internal/handler/http/subscription_handler.go
@@ -68,13 +68,13 @@ func (h *SubscriptionHandler) RemoveSubscription(c *gin.Context) {
 		return
 	}
 
-	sourceKey := c.Param("source_key")
-	if sourceKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "source_key is required"})
+	sourceSlug := c.Param("source_slug")
+	if sourceSlug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "source_slug is required"})
 		return
 	}
 
-	err := h.subUsecase.Delete(c.Request.Context(), userID.(string), sourceKey)
+	err := h.subUsecase.Delete(c.Request.Context(), userID.(string), sourceSlug)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/handler/http/topic_handler.go
+++ b/internal/handler/http/topic_handler.go
@@ -6,18 +6,43 @@ import (
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
 	"github.com/RealEskalate/G6-NewsBrief/internal/handler/http/dto"
-
 	"github.com/gin-gonic/gin"
 )
 
 type TopicHandler struct {
 	topicUsecase contract.ITopicUsecase
+	uuidGen      contract.IUUIDGenerator
 }
 
-func NewTopicHandler(topicUC contract.ITopicUsecase) *TopicHandler {
+func NewTopicHandler(topicUC contract.ITopicUsecase, uuidGen contract.IUUIDGenerator) *TopicHandler {
 	return &TopicHandler{
 		topicUsecase: topicUC,
+		uuidGen:      uuidGen,
 	}
+}
+func (h *TopicHandler) CreateTopic(c *gin.Context) {
+	var topicDTO dto.TopicDTO
+	if err := c.ShouldBindJSON(&topicDTO); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid request payload"})
+		return
+	}
+
+	topic := entity.Topic{
+		ID:   h.uuidGen.NewUUID(),
+		Slug: topicDTO.Slug,
+		Label: entity.BilingualField{
+			EN: topicDTO.Label.EN,
+			AM: topicDTO.Label.AM,
+		},
+		StoryCount: 0,
+	}
+
+	if err := h.topicUsecase.CreateTopic(c.Request.Context(), &topic); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Failed to create topic"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, dto.MessageResponse{Message: "Topic created successfully"})
 }
 
 // GetTopics handles the GET /v1/topics request.
@@ -29,29 +54,9 @@ func (h *TopicHandler) GetTopics(c *gin.Context) {
 	}
 
 	response := dto.TopicsResponseDTO{
-		Topics:      mapTopicsToDTOs(topics),
+		Topics:      dto.MapTopicsToDTOs(topics),
 		TotalTopics: len(topics),
 	}
 
 	c.JSON(http.StatusOK, response)
-}
-
-func mapTopicsToDTOs(topics []entity.Topic) []dto.TopicDTO {
-	topicDTOs := make([]dto.TopicDTO, len(topics))
-	for i, topic := range topics {
-		topicDTOs[i] = dto.TopicDTO{
-			Key: topic.Key,
-			Label: dto.BilingualFieldDTO{
-				EN: topic.Label.EN,
-				AM: topic.Label.AM,
-			},
-			Description: dto.BilingualFieldDTO{
-				EN: topic.Description.EN,
-				AM: topic.Description.AM,
-			},
-			ImageURL:   topic.ImageURL,
-			StoryCount: topic.StoryCount,
-		}
-	}
-	return topicDTOs
 }

--- a/internal/handler/http/user_handler.go
+++ b/internal/handler/http/user_handler.go
@@ -43,13 +43,13 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
-	_, err := h.userUsecase.Register(c.Request.Context(), req.Username, req.Email, req.Password, req.Fullname)
+	user, err := h.userUsecase.Register(c.Request.Context(), req.Username, req.Email, req.Password, req.Fullname)
 	if err != nil {
 		ErrorHandler(c, http.StatusConflict, err.Error())
 		return
 	}
 
-	MessageHandler(c, http.StatusCreated, "User created successfully. Please check your email to verify your account.")
+	SuccessHandler(c, http.StatusCreated, user)
 }
 
 // Login handles user authentication
@@ -185,7 +185,7 @@ func (h *UserHandler) RefreshToken(c *gin.Context) {
 
 	newAccessToken, newRefreshToken, err := h.userUsecase.RefreshToken(c.Request.Context(), req.RefreshToken)
 	if err != nil {
-		ErrorHandler(c, http.StatusUnauthorized, "Invalid or expired refresh token")
+		ErrorHandler(c, http.StatusUnauthorized, "Invalid or expired refresh token:"+err.Error())
 		return
 	}
 

--- a/internal/handler/http/user_handler.go
+++ b/internal/handler/http/user_handler.go
@@ -62,7 +62,7 @@ func (h *UserHandler) Login(c *gin.Context) {
 
 	user, accessToken, refreshToken, err := h.userUsecase.Login(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
-		ErrorHandler(c, http.StatusUnauthorized, "Invalid credentials or unverified email")
+		ErrorHandler(c, http.StatusUnauthorized, "Invalid credentials or unverified email: "+err.Error())
 		return
 	}
 

--- a/internal/handler/http/user_handler.go
+++ b/internal/handler/http/user_handler.go
@@ -62,7 +62,7 @@ func (h *UserHandler) Login(c *gin.Context) {
 
 	user, accessToken, refreshToken, err := h.userUsecase.Login(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
-		ErrorHandler(c, http.StatusUnauthorized, "Invalid credentials or unverified email: "+err.Error())
+		ErrorHandler(c, http.StatusUnauthorized, "Invalid credentials or unverified email")
 		return
 	}
 

--- a/internal/handler/http/user_handler.go
+++ b/internal/handler/http/user_handler.go
@@ -185,7 +185,7 @@ func (h *UserHandler) RefreshToken(c *gin.Context) {
 
 	newAccessToken, newRefreshToken, err := h.userUsecase.RefreshToken(c.Request.Context(), req.RefreshToken)
 	if err != nil {
-		ErrorHandler(c, http.StatusUnauthorized, "Invalid or expired refresh token:"+err.Error())
+		ErrorHandler(c, http.StatusUnauthorized, "Invalid or expired refresh token")
 		return
 	}
 

--- a/internal/infrastructure/jwt/adapter.go
+++ b/internal/infrastructure/jwt/adapter.go
@@ -49,6 +49,7 @@ func (a *JWTServiceAdapter) ParseRefreshToken(tokenStr string) (*entity.Claims, 
 	}
 	return &entity.Claims{
 		UserID:           customClaims.Subject,
+		Role:             entity.UserRole(customClaims.Role),
 		RegisteredClaims: customClaims.RegisteredClaims,
 	}, nil
 }

--- a/internal/infrastructure/jwt/jwt.go
+++ b/internal/infrastructure/jwt/jwt.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
-
 	"github.com/golang-jwt/jwt/v5"
 )
 

--- a/internal/infrastructure/repository/mongodb/source_repo.go
+++ b/internal/infrastructure/repository/mongodb/source_repo.go
@@ -13,25 +13,43 @@ type sourceRepository struct {
 	collection *mongo.Collection
 }
 
-func NewSourceRepository(db *mongo.Database) *sourceRepository {
+func NewSourceRepository(colln *mongo.Collection) *sourceRepository {
 	return &sourceRepository{
-		collection: db.Collection("sources"),
+		collection: colln,
 	}
 }
+func (r *sourceRepository) CreateSource(ctx context.Context, source *entity.Source) error {
+	_, err := r.collection.InsertOne(ctx, source)
 
-// Exists checks if a source with the given key exists. (Your code was perfect)
-func (r *sourceRepository) Exists(ctx context.Context, key string) (bool, error) {
-	count, err := r.collection.CountDocuments(ctx, bson.M{"key": key})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CheckSlugExists checks if a source with the given slug exists.
+func (r *sourceRepository) CheckSlugExists(ctx context.Context, slug string) (bool, error) {
+	count, err := r.collection.CountDocuments(ctx, bson.M{"slug": slug})
 	if err != nil {
 		return false, err
 	}
 	return count > 0, nil
 }
 
-// GetByKey retrieves a single source by its unique key.
-func (r *sourceRepository) GetByKey(ctx context.Context, key string) (*entity.Source, error) {
+// CheckURLExists checks if a source with the given URL exists.
+func (r *sourceRepository) CheckURLExists(ctx context.Context, url string) (bool, error) {
+	count, err := r.collection.CountDocuments(ctx, bson.M{"url": url})
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// GetBySlug retrieves a single source by its unique slug.
+func (r *sourceRepository) GetBySlug(ctx context.Context, slug string) (*entity.Source, error) {
 	var source entity.Source
-	err := r.collection.FindOne(ctx, bson.M{"key": key}).Decode(&source)
+	err := r.collection.FindOne(ctx, bson.M{"slug": slug}).Decode(&source)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, errors.New("source not found")

--- a/internal/infrastructure/repository/mongodb/token_repo.go
+++ b/internal/infrastructure/repository/mongodb/token_repo.go
@@ -98,6 +98,19 @@ func (r *TokenRepository) GetTokenByUserID(ctx context.Context, userID string) (
 	return token, nil
 }
 
+// get token by user id and token type
+func (r *TokenRepository) GetTokenByUserIDWithOpts(ctx context.Context, userID string, tokenType string) (*entity.Token, error) {
+	filter := bson.M{"user_id": userID, "token_type": tokenType, "revoke": false}
+	var dto tokenDTO
+	err := r.Collection.FindOne(ctx, filter).Decode(&dto)
+	if err != nil {
+		return nil, err
+	}
+	token := dto.ToEntity()
+
+	return token, nil
+}
+
 // UpdateToken updates the token hash and expiry
 func (r *TokenRepository) UpdateToken(ctx context.Context, tokenID string, tokenHash string, expiry time.Time) error {
 	filter := bson.M{"_id": tokenID}

--- a/internal/infrastructure/repository/mongodb/topic_repo.go
+++ b/internal/infrastructure/repository/mongodb/topic_repo.go
@@ -15,13 +15,29 @@ type topicRepository struct {
 }
 
 // NewTopicRepository creates a new MongoDB topic repository.
-func NewTopicRepository(db *mongo.Database) *topicRepository {
+func NewTopicRepository(colln *mongo.Collection) *topicRepository {
 	return &topicRepository{
-		collection: db.Collection("topics"),
+		collection: colln,
 	}
 }
 
-// GetAll retrieves all topics from the 'topics' collection. // CORRECTED COMMENT
+func (r *topicRepository) CreateTopic(ctx context.Context, topic *entity.Topic) error {
+	_, err := r.collection.InsertOne(ctx, topic)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *topicRepository) CheckSlugExists(ctx context.Context, slug string) (bool, error) {
+	count, err := r.collection.CountDocuments(ctx, bson.M{"slug": slug})
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// GetAll retrieves all topics from the 'topics' collection.
 func (r *topicRepository) GetAll(ctx context.Context) ([]entity.Topic, error) {
 	var topics []entity.Topic
 

--- a/internal/infrastructure/repository/mongodb/topic_repo.go
+++ b/internal/infrastructure/repository/mongodb/topic_repo.go
@@ -2,9 +2,7 @@ package mongodb
 
 import (
 	"context"
-
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -29,6 +27,16 @@ func (r *topicRepository) CreateTopic(ctx context.Context, topic *entity.Topic) 
 	return nil
 }
 
+func (r *topicRepository) GetTopicByID(ctx context.Context, topicID string) (*entity.Topic, error) {
+	filter := bson.M{"_id": topicID}
+	var topic entity.Topic
+	err := r.collection.FindOne(ctx, filter).Decode(&topic)
+	if err != nil {
+		return nil, err
+	}
+	return &topic, nil
+}
+
 func (r *topicRepository) CheckSlugExists(ctx context.Context, slug string) (bool, error) {
 	count, err := r.collection.CountDocuments(ctx, bson.M{"slug": slug})
 	if err != nil {
@@ -44,6 +52,24 @@ func (r *topicRepository) GetAll(ctx context.Context) ([]entity.Topic, error) {
 	// Sort by 'sort_order' as defined in the schema file
 	opts := options.Find().SetSort(bson.D{{Key: "sort_order", Value: 1}})
 	cursor, err := r.collection.Find(ctx, bson.D{}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	if err = cursor.All(ctx, &topics); err != nil {
+		return nil, err
+	}
+
+	return topics, nil
+}
+
+func (r *topicRepository) GetUserSubscribedTopics(ctx context.Context, userTopics []string) ([]*entity.Topic, error) {
+	// Local struct for decoding only the field we need.
+	var topics []*entity.Topic
+
+	filter := bson.M{"_id": bson.M{"$in": userTopics}}
+	cursor, err := r.collection.Find(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/repository/mongodb/user_repo.go
+++ b/internal/infrastructure/repository/mongodb/user_repo.go
@@ -14,20 +14,20 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-type MongoUserRepository struct {
+type UserRepository struct {
 	collection *mongo.Collection
 }
 
-func NewMongoUserRepository(collection *mongo.Collection) *MongoUserRepository {
-	return &MongoUserRepository{collection: collection}
+func NewUserRepository(collection *mongo.Collection) *UserRepository {
+	return &UserRepository{collection: collection}
 }
 
-func (r *MongoUserRepository) CreateUser(ctx context.Context, user *entity.User) error {
+func (r *UserRepository) CreateUser(ctx context.Context, user *entity.User) error {
 	_, err := r.collection.InsertOne(ctx, user)
 	return err
 }
 
-func (r *MongoUserRepository) GetUserByID(ctx context.Context, id string) (*entity.User, error) {
+func (r *UserRepository) GetUserByID(ctx context.Context, id string) (*entity.User, error) {
 	var user entity.User
 	err := r.collection.FindOne(ctx, bson.M{"_id": id}).Decode(&user)
 	if err != nil {
@@ -36,7 +36,7 @@ func (r *MongoUserRepository) GetUserByID(ctx context.Context, id string) (*enti
 	return &user, nil
 }
 
-func (r *MongoUserRepository) GetUserByEmail(ctx context.Context, email string) (*entity.User, error) {
+func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (*entity.User, error) {
 	var user entity.User
 	err := r.collection.FindOne(ctx, bson.M{"email": email}).Decode(&user)
 	if err != nil {
@@ -48,7 +48,7 @@ func (r *MongoUserRepository) GetUserByEmail(ctx context.Context, email string) 
 	return &user, nil
 }
 
-func (r *MongoUserRepository) GetUserByUsername(ctx context.Context, username string) (*entity.User, error) {
+func (r *UserRepository) GetUserByUsername(ctx context.Context, username string) (*entity.User, error) {
 	var user entity.User
 	err := r.collection.FindOne(ctx, bson.M{"username": username}).Decode(&user)
 	if err != nil {
@@ -60,7 +60,7 @@ func (r *MongoUserRepository) GetUserByUsername(ctx context.Context, username st
 	return &user, nil
 }
 
-func (r *MongoUserRepository) GetByUserName(ctx context.Context, username string) (*entity.User, error) {
+func (r *UserRepository) GetByUserName(ctx context.Context, username string) (*entity.User, error) {
 	var user entity.User
 	err := r.collection.FindOne(ctx, bson.M{"username": username}).Decode(&user)
 	if err != nil {
@@ -70,7 +70,7 @@ func (r *MongoUserRepository) GetByUserName(ctx context.Context, username string
 }
 
 // UpdateUser updates an existing user and returns the updated user
-func (r *MongoUserRepository) UpdateUser(ctx context.Context, user *entity.User) (*entity.User, error) {
+func (r *UserRepository) UpdateUser(ctx context.Context, user *entity.User) (*entity.User, error) {
 	user.UpdatedAt = time.Now()
 	filter := bson.M{"_id": user.ID}
 	update := bson.M{"$set": user}
@@ -89,7 +89,7 @@ func (r *MongoUserRepository) UpdateUser(ctx context.Context, user *entity.User)
 	return &updatedUser, nil
 }
 
-func (r *MongoUserRepository) UpdateUserPassword(ctx context.Context, id string, hashedPassword string) error {
+func (r *UserRepository) UpdateUserPassword(ctx context.Context, id string, hashedPassword string) error {
 	filter := bson.M{"_id": id}
 	update := bson.M{"$set": bson.M{"password_hash": hashedPassword}}
 	count, err := r.collection.UpdateOne(ctx, filter, update)
@@ -103,7 +103,7 @@ func (r *MongoUserRepository) UpdateUserPassword(ctx context.Context, id string,
 	return nil
 }
 
-func (r *MongoUserRepository) DeleteUser(ctx context.Context, id string) error {
+func (r *UserRepository) DeleteUser(ctx context.Context, id string) error {
 	filter := bson.M{"_id": id}
 	count, err := r.collection.DeleteOne(ctx, filter)
 	if err != nil {
@@ -117,7 +117,7 @@ func (r *MongoUserRepository) DeleteUser(ctx context.Context, id string) error {
 
 // AddSubscription adds a source key to the user's embedded list of subscriptions.
 // It uses $addToSet to automatically prevent duplicates.
-func (r *MongoUserRepository) AddSubscription(ctx context.Context, id string, sourceKey string) error {
+func (r *UserRepository) AddSubscription(ctx context.Context, id string, sourceKey string) error {
 	filter := bson.M{"_id": id}
 	update := bson.M{
 		"$addToSet": bson.M{"preferences.subscribed_sources": sourceKey},
@@ -135,7 +135,7 @@ func (r *MongoUserRepository) AddSubscription(ctx context.Context, id string, so
 }
 
 // RemoveSubscription removes a source key from the user's embedded list of subscriptions.
-func (r *MongoUserRepository) RemoveSubscription(ctx context.Context, id string, sourceKey string) error {
+func (r *UserRepository) RemoveSubscription(ctx context.Context, id string, sourceKey string) error {
 	filter := bson.M{"_id": id}
 	update := bson.M{
 		"$pull": bson.M{"preferences.subscribed_sources": sourceKey},
@@ -154,7 +154,7 @@ func (r *MongoUserRepository) RemoveSubscription(ctx context.Context, id string,
 
 // GetSubscriptions retrieves only the list of subscribed source keys for a user.
 // This uses a projection for efficiency, so the entire user document is not fetched.
-func (r *MongoUserRepository) GetSubscriptions(ctx context.Context, id string) ([]string, error) {
+func (r *UserRepository) GetSubscriptions(ctx context.Context, id string) ([]string, error) {
 	// Local struct for decoding only the field we need.
 	var result struct {
 		Preferences struct {
@@ -175,4 +175,42 @@ func (r *MongoUserRepository) GetSubscriptions(ctx context.Context, id string) (
 
 	// Return an empty slice if the field is null or missing, which is the correct behavior.
 	return result.Preferences.SubscribedSources, nil
+}
+
+func (r *UserRepository) SubscribeTopic(ctx context.Context, userID, topicID string) error {
+	filter := bson.M{"_id": userID}
+	update := bson.D{{
+		Key:   "$addToSet",
+		Value: bson.M{"preferences.topics": topicID},
+	}}
+	count, err := r.collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+
+	if count.MatchedCount == 0 {
+		return errors.New("user not found")
+	}
+	return nil
+}
+
+func (r *UserRepository) GetUserSubscribedTopicsByID(ctx context.Context, userID string) ([]string, error) {
+	filter := bson.M{"_id": userID}
+	projection := bson.M{"preferences.topics": 1, "_id": 0}
+	opts := options.FindOne().SetProjection(projection)
+
+	var result struct {
+		Preferences struct {
+			Topics []string `bson:"topics"`
+		} `bson:"preferences"`
+	}
+
+	if err := r.collection.FindOne(ctx, filter, opts).Decode(&result); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, errors.New("user not found")
+		}
+		return nil, err
+	}
+
+	return result.Preferences.Topics, nil
 }

--- a/internal/infrastructure/seeder/seed.go
+++ b/internal/infrastructure/seeder/seed.go
@@ -10,7 +10,7 @@ import (
 	"github.com/RealEskalate/G6-NewsBrief/internal/handler/http/dto"
 )
 
-// SeedAdminUsingUC creates an admin via UserUsecase.Register, then clears topics/subscriptions (nil)
+// SeedAdminUsingUC creates an admin via UserUsecase.Register, then sets topics/subscriptions to nil (Go nil slice, not empty slice)
 // and ensures the role is admin. Safe to run multiple times.
 func SeedAdminUsingUC(
 	ctx context.Context,

--- a/internal/infrastructure/seeder/seed.go
+++ b/internal/infrastructure/seeder/seed.go
@@ -1,0 +1,66 @@
+package seeder
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
+	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
+	"github.com/RealEskalate/G6-NewsBrief/internal/handler/http/dto"
+)
+
+// SeedAdminUsingUC creates an admin via UserUsecase.Register, then clears topics/subscriptions (nil)
+// and ensures the role is admin. Safe to run multiple times.
+func SeedAdminUsingUC(
+	ctx context.Context,
+	userUC contract.IUserUseCase,
+	userRepo contract.IUserRepository,
+	email, password string,
+) error {
+	// Check if user exists by email
+	existing, err := userRepo.GetUserByEmail(ctx, email)
+	if err == nil && existing != nil {
+		// Normalize: topics/subscriptions nil and role admin
+		existing.Preferences.Topics = nil
+		existing.Preferences.SubscribedSources = nil
+		existing.Role = entity.UserRoleAdmin
+		existing.IsVerified = true
+		existing.UpdatedAt = time.Now()
+
+		if _, err := userRepo.UpdateUser(ctx, existing); err != nil {
+			return fmt.Errorf("seeder: failed to normalize existing admin: %w", err)
+		}
+		return nil
+	}
+
+	// Create via usecase (adjust fields to match your dto.RegisterRequest)
+	req := dto.RegisterRequest{
+		Email:    email,
+		Password: password,
+		Fullname: "admin",
+		Username: "admin",
+	}
+
+	if _, err := userUC.Register(ctx, req.Username, req.Email, req.Password, req.Fullname); err != nil {
+		return fmt.Errorf("seeder: register failed: %w", err)
+	}
+
+	// Fetch newly created user and normalize
+	u, err := userRepo.GetUserByEmail(ctx, email)
+	if err != nil || u == nil {
+		return fmt.Errorf("seeder: failed to fetch newly created admin: %w", err)
+	}
+
+	u.Preferences.Topics = nil
+	u.Preferences.SubscribedSources = nil
+	u.Role = entity.UserRoleAdmin
+	u.IsVerified = true
+	u.UpdatedAt = time.Now()
+
+	if _, err := userRepo.UpdateUser(ctx, u); err != nil {
+		return fmt.Errorf("seeder: failed to finalize admin normalization: %w", err)
+	}
+
+	return nil
+}

--- a/internal/usecase/source_usecase.go
+++ b/internal/usecase/source_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
@@ -16,6 +17,29 @@ func NewSourceUsecase(sourceRepo contract.ISourceRepository) contract.ISourceUse
 	return &sourceUsecase{
 		sourceRepo: sourceRepo,
 	}
+}
+func (uc *sourceUsecase) CreateSource(ctx context.Context, source *entity.Source) error {
+	if source == nil {
+		return errors.New("source cannot be nil")
+	}
+
+	if source.Slug == "" {
+		return errors.New("source slug cannot be empty")
+	}
+
+	if exists, _ := uc.sourceRepo.CheckSlugExists(ctx, source.Slug); exists {
+		return errors.New("source with slug already exists")
+	}
+
+	urlExists, err := uc.sourceRepo.CheckURLExists(ctx, source.URL)
+	if err != nil {
+		return errors.New("could not validate source")
+	}
+	if urlExists {
+		return errors.New("source with URL already exists")
+	}
+
+	return uc.sourceRepo.CreateSource(ctx, source)
 }
 
 // GetAll fetches all source definitions from the repository.

--- a/internal/usecase/topic_usecase.go
+++ b/internal/usecase/topic_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/contract"
 	"github.com/RealEskalate/G6-NewsBrief/internal/domain/entity"
@@ -16,6 +17,22 @@ func NewTopicUsecase(topicRepo contract.ITopicRepository) contract.ITopicUsecase
 	return &topicUsecase{
 		topicRepo: topicRepo,
 	}
+}
+func (uc *topicUsecase) CreateTopic(ctx context.Context, topic *entity.Topic) error {
+	if topic == nil {
+		return errors.New("topic cannot be nil")
+	}
+	if topic.Slug == "" {
+		return errors.New("topic slug cannot be empty")
+	}
+	exists, err := uc.topicRepo.CheckSlugExists(ctx, topic.Slug)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return errors.New("topic with slug already exists")
+	}
+	return uc.topicRepo.CreateTopic(ctx, topic)
 }
 
 // ListAll fetches all topic definitions.

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -122,7 +122,7 @@ func (uc *UserUsecase) Register(ctx context.Context, username, email, password, 
 	}
 
 	// Send activation email if required, using config from injected ConfigProvider
-	if uc.config.GetSendActivationEmail() {
+	if uc.config.GetSendActivationEmail() && user.Role != "admin" {
 		// Generate email verification token
 		if err = uc.emailUsecase.RequestVerificationEmail(ctx, user); err != nil {
 			return nil, fmt.Errorf("failed to send verification email")

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -24,6 +24,7 @@ const (
 type UserUsecase struct {
 	userRepo        contract.IUserRepository
 	tokenRepo       contract.ITokenRepository
+	topicRepo       contract.ITopicRepository
 	emailUsecase    contract.IEmailVerificationUC
 	hasher          contract.IHasher
 	jwtService      contract.IJWTService
@@ -39,6 +40,7 @@ type UserUsecase struct {
 func NewUserUsecase(
 	userRepo contract.IUserRepository,
 	tokenRepo contract.ITokenRepository,
+	topicRepo contract.ITopicRepository,
 	emailUC contract.IEmailVerificationUC,
 	hasher contract.IHasher,
 	jwtService contract.IJWTService,
@@ -52,6 +54,7 @@ func NewUserUsecase(
 	return &UserUsecase{
 		userRepo:        userRepo,
 		tokenRepo:       tokenRepo,
+		topicRepo:       topicRepo,
 		emailUsecase:    emailUC,
 		hasher:          hasher,
 		jwtService:      jwtService,
@@ -192,7 +195,13 @@ func (uc *UserUsecase) Login(ctx context.Context, email, password string) (*enti
 		CreatedAt: time.Now(),
 		Revoke:    false,
 	}
-	if err := uc.tokenRepo.CreateToken(ctx, tokenEntity); err != nil {
+
+	if foundToken, err := uc.tokenRepo.GetTokenByUserIDWithOpts(ctx, user.ID, string(entity.TokenTypeRefresh)); err == nil {
+		if err := uc.tokenRepo.UpdateToken(ctx, foundToken.ID, tokenEntity.TokenHash, tokenEntity.ExpiresAt); err != nil {
+			uc.logger.Errorf("failed to update refresh token for user %s: %v", user.ID, err)
+			return nil, "", "", errors.New("failed to store token")
+		}
+	} else if err := uc.tokenRepo.CreateToken(ctx, tokenEntity); err != nil {
 		uc.logger.Errorf("failed to store refresh token for user %s: %v", user.ID, err)
 		return nil, "", "", errors.New("failed to store token")
 	}
@@ -236,7 +245,7 @@ func (uc *UserUsecase) RefreshToken(ctx context.Context, refreshToken string) (s
 
 	// Retrieve the stored token using the parsed UUID.
 	uc.logger.Infof("Debug: Looking up stored token for user: %s", userID)
-	storedToken, err := uc.tokenRepo.GetTokenByUserID(ctx, userID)
+	storedToken, err := uc.tokenRepo.GetTokenByUserIDWithOpts(ctx, userID, string(entity.TokenTypeRefresh))
 	if err != nil {
 		uc.logger.Errorf("Debug: Failed to retrieve stored token: %v", err)
 		if err.Error() == "token not found" {
@@ -246,7 +255,7 @@ func (uc *UserUsecase) RefreshToken(ctx context.Context, refreshToken string) (s
 		return "", "", errors.New(errInternalServer)
 	}
 	uc.logger.Infof("Debug: Found stored token with hash length: %d", len(storedToken.TokenHash))
-
+	fmt.Printf("Debug: Stored token details: %+v\n", storedToken)
 	// Check if the token has been revoked.
 	if storedToken.Revoke {
 		return "", "", errors.New("refresh token has been revoked, please log in again")
@@ -651,4 +660,36 @@ func (uc *UserUsecase) UpdatePreferences(ctx context.Context, userID string, req
 
 	// 4. Return the updated preferences object to be used in the handler response.
 	return &user.Preferences, nil
+}
+
+func (uc *UserUsecase) SubscribeTopic(ctx context.Context, userID, topicID string) error {
+	if userID == "" || topicID == "" {
+		return errors.New("user ID and topic ID are required")
+	}
+	if _, err := uc.topicRepo.GetTopicByID(ctx, topicID); err != nil {
+		return errors.New("topic not found")
+	}
+	if _, err := uc.userRepo.GetUserByID(ctx, userID); err != nil {
+		return errors.New("user not found")
+	}
+
+	if err := uc.userRepo.SubscribeTopic(ctx, userID, topicID); err != nil {
+		return errors.New("failed to subscribe user to topic")
+	}
+	return nil
+}
+
+func (uc *UserUsecase) GetUserSubscribedTopics(ctx context.Context, userID string) ([]*entity.Topic, error) {
+	if userID == "" {
+		return nil, errors.New("user ID is required")
+	}
+	result, err := uc.userRepo.GetUserSubscribedTopicsByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	userTopics, err := uc.topicRepo.GetUserSubscribedTopics(ctx, result)
+	if err != nil {
+		return nil, err
+	}
+	return userTopics, nil
 }

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -152,10 +152,11 @@ func (uc *UserUsecase) Login(ctx context.Context, email, password string) (*enti
 		return nil, "", "", errors.New(errInternalServer)
 	}
 
+	// uncommented on sept-1-2025 because user email verification is not mandatory. A decision was made to allow login without email verification
 	// Check if the user's email is active/verified
-	if !user.IsVerified {
-		return nil, "", "", errors.New("account not active. Please verify your email")
-	}
+	// if !user.IsVerified {
+	// 	return nil, "", "", errors.New("account not active. Please verify your email")
+	// }
 
 	// Verify password
 	if err := uc.hasher.ComparePasswordHash(password, user.PasswordHash); err != nil {

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -255,7 +255,7 @@ func (uc *UserUsecase) RefreshToken(ctx context.Context, refreshToken string) (s
 		return "", "", errors.New(errInternalServer)
 	}
 	uc.logger.Infof("Debug: Found stored token with hash length: %d", len(storedToken.TokenHash))
-	fmt.Printf("Debug: Stored token details: %+v\n", storedToken)
+	uc.logger.Debugf("Stored token details: %+v", storedToken)
 	// Check if the token has been revoked.
 	if storedToken.Revoke {
 		return "", "", errors.New("refresh token has been revoked, please log in again")


### PR DESCRIPTION
This pull request introduces several major enhancements and refactors to the codebase, focusing on improved admin seeding, expanded API documentation, and significant updates to the contracts and entities for topics and sources. The changes also include dependency updates and various improvements for extensibility and maintainability.

**Major improvements and new features:**

* Adds admin seeding capability on application start, configurable via environment variables and command-line flags.
* Expands and documents the User & Auth API, including endpoints for authentication, user management, subscriptions, and admin actions.
* Refactors and extends contracts and entities for sources and topics, improving clarity and future extensibility.

---

### Admin seeding and configuration

- Adds an `adminSeeder` function in `main.go` to seed an admin user on startup, controlled via the `SEED_ON_START`, `SEED_ADMIN_EMAIL`, and `SEED_ADMIN_PASSWORD` environment variables and a `-seed` flag. Updates `.env.sample` accordingly. [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afR20-R59) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL82-R136) [[3]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cR27-R36)

### API documentation

- Adds comprehensive API documentation for user management, authentication, subscriptions, and admin endpoints in `docs/User_management.md`.

### Contracts and entities refactor

**Sources:**
- Updates the source entity to use `Slug` instead of `Key`, introduces a `LanguageType` enum, and refines repository and usecase contracts for clarity and future expansion. [[1]](diffhunk://#diff-7b1413aff2f1d00c0b8174c9e9c4d31257d0dd31284f006e1bd5a3ff068cbe91L3-R34) [[2]](diffhunk://#diff-c0ce42f4c1cdf7e7f69cd81d4652fc0f8d2bb35a0acb86b95e198de0ca0c2cf1L5-R15) [[3]](diffhunk://#diff-94752e09f3daf4e9a20d7b940c71a4477c24b3c90760adc804c74d255011a9b8R11)

**Topics:**
- Refactors the topic entity to use `Slug` instead of `Key`, removes unnecessary fields, and updates repository and usecase contracts for topic creation, slug checking, and user-topic relationships. [[1]](diffhunk://#diff-8e7b88ad3cffa4987604062b7736ff0afa73052bf7847ed08e1d86b18672f9cbL3-L4) [[2]](diffhunk://#diff-8e7b88ad3cffa4987604062b7736ff0afa73052bf7847ed08e1d86b18672f9cbL13-L19) [[3]](diffhunk://#diff-77686a400913dfa4f0938a632d08c104e7bcd2c13c8e78bea8eda2b911716834R11-R16) [[4]](diffhunk://#diff-7c7f076611b10ae55a83c7d55250fae5b94340af882ae1da1dd7029c0bc4ff9aL5-R10)

**Users and tokens:**
- Extends user and token contracts to support topic subscriptions and retrieval, and adds role information to refresh token claims. [[1]](diffhunk://#diff-8ce334f13206515b76d7bdc531c210a8ae4b610ff4f08ee259c399878f8527aeR28-R29) [[2]](diffhunk://#diff-640146e958104d84cc7055b15e0a5ae3925c7ed40b9d5c849a8c549e1fb59decR25-R26) [[3]](diffhunk://#diff-b3842033bbf0c4a74f1d0464de358dbe1ada84c0ef689119e47ec400f3c9d41eR18) [[4]](diffhunk://#diff-b5e51a5f035cd727e8a2a00c99b237d64d03fc327d1f93317106ead1bd6962dbR14)

### Dependency and code hygiene

- Adds the `github.com/mssola/user_agent` dependency and performs minor import cleanups. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R13) [[2]](diffhunk://#diff-3b9cce7540737147ad376ceb097a8599083bd148c0a00710a03d01d645b3f019L5-R6) [[3]](diffhunk://#diff-f163a730613b62a05eb1464ea376ae29e8fac501cf7cc63b490186ed5bc2dd95L4-R5) [[4]](diffhunk://#diff-f163a730613b62a05eb1464ea376ae29e8fac501cf7cc63b490186ed5bc2dd95R32) [[5]](diffhunk://#diff-f163a730613b62a05eb1464ea376ae29e8fac501cf7cc63b490186ed5bc2dd95L16-L17)

---

These changes collectively improve the maintainability, extensibility, and clarity of the codebase, while also providing better documentation and initial data setup for development and deployment.